### PR TITLE
Only run composer install if the .lock file doesn't exist

### DIFF
--- a/modules/composer/manifests/init.pp
+++ b/modules/composer/manifests/init.pp
@@ -34,6 +34,7 @@ class composer (
 			command     => 'composer install',
 			require     => [ Exec['install composer'] ],
 			logoutput   => true,
+			onlyif      => "test ! -f composer.lock"
 		}
 	}
 

--- a/modules/composer/manifests/init.pp
+++ b/modules/composer/manifests/init.pp
@@ -34,7 +34,7 @@ class composer (
 			command     => 'composer install',
 			require     => [ Exec['install composer'] ],
 			logoutput   => true,
-			onlyif      => "test ! -f composer.lock"
+			onlyif      => 'test ! -f composer.lock'
 		}
 	}
 


### PR DESCRIPTION
Fixes #30.